### PR TITLE
Set copyright year/owner in LICENSE

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -186,7 +186,7 @@
       same "printed page" as the copyright notice for easier
       identification within third-party archives.
 
-   Copyright [yyyy] [name of copyright owner]
+   Copyright 2021 The K8ssandra Team and Contributors
 
    Licensed under the Apache License, Version 2.0 (the "License");
    you may not use this file except in compliance with the License.


### PR DESCRIPTION
Setting the copyright year/owner in your LICENSE is an important part of ensuring that people who fork your repo can properly comply with the Apache license by marking you as the original copyright holder.